### PR TITLE
Base features

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,27 +2,34 @@
 Dot is an elegant and simple dotfiles manager for *unix, inspired by [GNU Stow](https://www.gnu.org/software/stow/).
 
 ## Usage
-Initially, you must create the package within your dotfiles directory:
+Initially, place you dotfiles in the folder you use to manage them. Then, map the structure to a config file called `dot.toml` like this:
 
-```sh
-# Creating a package for nvim
-mkdir nvim/.config/
-mv ~/.config/nvim nvim/.config/nvim
+```toml
+[dot]
+source_path = 'dotfiles' # the base folder where your dotfiles are centralized
+
+[dotfiles]
+files = [ # list of dotfiles
+    { 
+        source = '.gitconfig', # source dotfile (considering the source path as base)
+        destination = '~/.gitconfig' # place where you be in your machine (use absolute path or the ~ to represent HOME
+    },
+    { source = '.bashrc', destination = '~/.bashrc' },
+]
 ```
 
-With your *dot* packages available, you can push them to your machine:
+With your *dot* packages available, you can sync them to the right place in your machine:
+
 
 ```sh
-dot nvim
+dot sync
 ```
 
-```sh
-dot ghostty
-```
+> `dot sync` works by creating symbolic links.
 
 ## Roadmap 
 - [X] Move away from Swift adopting Rust or Zig languages
-- [X] Include support to "dot-" prefix pre-processing based on a --dotfiles flag (similar to `stow <package> --dotfiles` behavior);
+- [ ] Include support to "dot-" prefix pre-processing based on a --dotfiles flag (similar to `stow <package> --dotfiles` behavior);
 - [ ] Include a command to add a package in the dot directory, using --adopt flag (running the `mkdir` and `mv` commands can be quite boring);
 
 ## Installation

--- a/build.zig
+++ b/build.zig
@@ -8,7 +8,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
-        .strip = true,
+        .strip = optimize != .Debug,
     });
 
     const exe = b.addExecutable(.{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .dot,
-    .version = "0.0.0",
+    .version = "0.0.1",
     .fingerprint = 0x59278a30c3f2fbc,
     .minimum_zig_version = "0.14.1",
     .dependencies = .{

--- a/examples/example.toml
+++ b/examples/example.toml
@@ -1,0 +1,8 @@
+[dot]
+dotpath = 'dotfiles'
+
+[dotfiles]
+files = [
+    { source = '.gitconfig', destination = '~/.gitconfig' },
+    { source = '.bashrc', destination = '~/.bashrc' },
+]

--- a/examples/example.toml
+++ b/examples/example.toml
@@ -1,5 +1,5 @@
 [dot]
-dotpath = 'dotfiles'
+source_path = 'dotfiles'
 
 [dotfiles]
 files = [

--- a/src/cli/help.zig
+++ b/src/cli/help.zig
@@ -1,0 +1,18 @@
+const std = @import("std");
+
+pub fn printHelp() noreturn {
+    std.debug.print(
+        \\Usage: dot [COMMAND] [OPTIONS]
+        \\
+        \\Commands:
+        \\ (no command)    Print this message and exits.
+        \\ sync            Reads dot.toml and create symbolic links.
+        \\
+        \\Options:
+        \\ --help, -h      Print this message and exits.
+        \\ --version, -v   Print dot version.
+        \\
+    , .{});
+
+    std.process.exit(1);
+}

--- a/src/cli/sync.zig
+++ b/src/cli/sync.zig
@@ -1,0 +1,60 @@
+const std = @import("std");
+const toml = @import("toml");
+
+const DotfilesHashMap = struct {
+    source: []const u8,
+    destination: []const u8,
+};
+
+const Dotfiles = struct {
+    files: []DotfilesHashMap,
+};
+
+const Dot = struct {
+    dotpath: []const u8,
+};
+
+// Represents the whole dot.toml config file
+const Config = struct {
+    dot: Dot,
+    dotfiles: Dotfiles,
+};
+
+pub fn sync() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    var parser = toml.Parser(Config).init(allocator);
+    defer parser.deinit();
+
+    const result = parser.parseFile("dot.toml") catch |err| return err;
+    defer result.deinit();
+
+    const config = result.value;
+    const home_dir = try std.process.getEnvVarOwned(allocator, "HOME");
+
+    const dotfile_path_buffer = try allocator.alloc(u8, 256);
+    defer allocator.free(dotfile_path_buffer);
+
+    for (config.dotfiles.files) |file| {
+        const mounted_dotfile_source = std.fmt.bufPrint(
+            dotfile_path_buffer,
+            "./{s}/{s}",
+            .{ config.dot.dotpath, file.source },
+        ) catch |err| {
+            return err;
+        };
+        const output_buffer = try allocator.alloc(u8, file.destination.len + home_dir.len - 1);
+        defer allocator.free(output_buffer);
+
+        _ = std.mem.replace(u8, file.destination, "~", home_dir, output_buffer);
+
+        std.posix.symlink(mounted_dotfile_source, output_buffer) catch |err| {
+            switch (err) {
+                error.PathAlreadyExists => std.debug.print("Yay, it is already created\n", .{}),
+                else => return err,
+            }
+        };
+    }
+}

--- a/src/cli/sync.zig
+++ b/src/cli/sync.zig
@@ -54,7 +54,7 @@ pub fn sync() !void {
 
         std.posix.symlink(mounted_dotfile_source, output_path) catch |err| {
             switch (err) {
-                error.PathAlreadyExists => std.debug.print("Yay, it is already created\n", .{}),
+                error.PathAlreadyExists => std.debug.print("{s} already synced.\n", .{file.source}),
                 else => return err,
             }
         };

--- a/src/cli/sync.zig
+++ b/src/cli/sync.zig
@@ -54,9 +54,14 @@ pub fn sync() !void {
 
         std.posix.symlink(mounted_dotfile_source, output_path) catch |err| {
             switch (err) {
-                error.PathAlreadyExists => std.debug.print("{s} already synced.\n", .{file.source}),
+                error.PathAlreadyExists => {
+                    std.debug.print("No changes, already synced: {s}.\n", .{file.source});
+                    continue;
+                },
                 else => return err,
             }
         };
+        std.debug.print("Successfully synced {s}.\n", .{file.source});
+
     }
 }

--- a/src/cli/sync.zig
+++ b/src/cli/sync.zig
@@ -11,7 +11,7 @@ const Dotfiles = struct {
 };
 
 const Dot = struct {
-    dotpath: []const u8,
+    source_path: []const u8,
 };
 
 // Represents the whole dot.toml config file
@@ -45,7 +45,7 @@ pub fn sync() !void {
         const mounted_dotfile_source = try std.fmt.allocPrint(
             allocator,
             "{s}/{s}/{s}",
-            .{ pwd, config.dot.dotpath, file.source },
+            .{ pwd, config.dot.source_path, file.source },
         );
         defer allocator.free(mounted_dotfile_source);
 

--- a/src/cli/sync.zig
+++ b/src/cli/sync.zig
@@ -33,9 +33,7 @@ pub fn sync() !void {
 
     const config = result.value;
     const home_dir = try std.process.getEnvVarOwned(allocator, "HOME");
-
-    const dotfile_path_buffer = try allocator.alloc(u8, 256);
-    defer allocator.free(dotfile_path_buffer);
+    defer allocator.free(home_dir);
 
     for (config.dotfiles.files) |file| {
         const mounted_dotfile_source = std.fmt.bufPrint(

--- a/src/cli/sync.zig
+++ b/src/cli/sync.zig
@@ -38,11 +38,14 @@ pub fn sync() !void {
     const home_dir = try std.process.getEnvVarOwned(allocator, "HOME");
     defer allocator.free(home_dir);
 
+    const pwd = try std.process.getEnvVarOwned(allocator, "PWD");
+    defer allocator.free(pwd);
+
     for (config.dotfiles.files) |file| {
         const mounted_dotfile_source = try std.fmt.allocPrint(
             allocator,
-            "./{s}/{s}",
-            .{ config.dot.dotpath, file.source },
+            "{s}/{s}/{s}",
+            .{ pwd, config.dot.dotpath, file.source },
         );
         defer allocator.free(mounted_dotfile_source);
 

--- a/src/cli/version.zig
+++ b/src/cli/version.zig
@@ -1,0 +1,6 @@
+const std = @import("std");
+
+pub fn printVersion() !void {
+    const stdout = std.io.getStdOut().writer();
+    try stdout.print("0.0.1", .{});
+}

--- a/src/config/dot_toml.zig
+++ b/src/config/dot_toml.zig
@@ -1,0 +1,19 @@
+const std = @import("std");
+const DotfilesHashMap = struct {
+    source: []const u8,
+    destination: []const u8,
+};
+
+const Dotfiles = struct {
+    files: []DotfilesHashMap,
+};
+
+const Dot = struct {
+    source_path: []const u8,
+};
+
+// Represents the whole dot.toml config file
+pub const Config = struct {
+    dot: Dot,
+    dotfiles: Dotfiles,
+};

--- a/src/config/dot_toml.zig
+++ b/src/config/dot_toml.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+
 const DotfilesHashMap = struct {
     source: []const u8,
     destination: []const u8,

--- a/src/config/parse_toml.zig
+++ b/src/config/parse_toml.zig
@@ -1,0 +1,16 @@
+const std = @import("std");
+const toml = @import("toml");
+
+const Config = @import("../config/dot_toml.zig").Config;
+
+pub fn parseDotToml(allocator: std.mem.Allocator) !Config {
+    var parser = toml.Parser(Config).init(allocator);
+    defer parser.deinit();
+
+    const result = parser.parseFile("dot.toml") catch |err| {
+        std.debug.print("Could not find dot.toml.\n", .{});
+        return err;
+    };
+
+    return result.value;
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,32 +1,40 @@
-pub fn main() !void {
-    std.debug.print("All your {s} are belong to us.\n", .{"codebase"});
-
-    const stdout_file = std.io.getStdOut().writer();
-    var bw = std.io.bufferedWriter(stdout_file);
-    const stdout = bw.writer();
-
-    try stdout.print("Run `zig build test` to run the tests.\n", .{});
-
-    try bw.flush(); // Don't forget to flush!
-}
-
-test "simple test" {
-    var list = std.ArrayList(i32).init(std.testing.allocator);
-    defer list.deinit(); // Try commenting this out and see if zig detects the memory leak!
-    try list.append(42);
-    try std.testing.expectEqual(@as(i32, 42), list.pop());
-}
-
-test "fuzz example" {
-    const Context = struct {
-        fn testOne(context: @This(), input: []const u8) anyerror!void {
-            _ = context;
-            // Try passing `--fuzz` to `zig build test` and see if it manages to fail this test case!
-            try std.testing.expect(!std.mem.eql(u8, "canyoufindme", input));
-        }
-    };
-    try std.testing.fuzz(Context{}, Context.testOne, .{});
-}
-
 const std = @import("std");
+const toml = @import("toml");
 
+const DotfilesHashMap = struct {
+    source: []const u8,
+    destination: []const u8,
+};
+const Dotfiles = struct {
+    files: []DotfilesHashMap,
+};
+
+const Dot = struct {
+    dotpath: []const u8,
+};
+
+// Represents the whole dot.toml config file
+const Config = struct {
+    dot: Dot,
+    dotfiles: Dotfiles,
+};
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    var parser = toml.Parser(Config).init(allocator);
+    defer parser.deinit();
+
+    var result = try parser.parseFile("./examples/example.toml");
+    defer result.deinit();
+
+    const config = result.value;
+
+    std.debug.print("{s}\n", .{config.dot.dotpath});
+
+    for (config.dotfiles.files) |file| {
+        std.debug.print("{s}\n", .{file.source});
+    }
+}


### PR DESCRIPTION
# Changes
This PR implements the base features of dot. In order to merge this PR we should have the following:
- [x] A `dot --version` flag
- [x] A `dot sync` command, which creates the symlinks based on `dot.toml`

# Explanation

`dot` will work by reading a config file and then creating symbolic link to it.

#  Config file proposal

Our configuration file is in `toml` format and must be named `dot.toml`. This is an example:
 ```toml
 [dot]
dotpath = 'dotfiles'

[dotfiles]
files = [
    { source = '.gitconfig', destination = '~/.gitconfig' },
    { source = '.bashrc', destination = '~/.bashrc' },
]
```

## Tables

### dot
The `dot` table is where top-level configuration lives, anything related to the CLI itself and/or global stuff. For now, it has only a field called `dotpath`, wich is the base path for your configuration files.

### dotfiles
The `dotfiles` table contains a single field called `files`, which is a list of inline tables. Each inline table must contain the keys `source`, which is the path to the file you want to create the symbolic link (already considering the starting point of `dotpath`, you do not need to repeat it). And `destination`, which is the place in you local machine where the symbolic link should be created.